### PR TITLE
Changed ansible-galaxy location for java dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ install:
   - "{ echo '[defaults]'; echo 'roles_path = ../'; } >> ansible.cfg"
 
   # Install required dependencies.
-  - ansible-galaxy install geerlingguy.java
+  - ansible-galaxy install telusdigital.java
 
 script:
   # Check the role/playbook's syntax.

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,8 +1,7 @@
 ---
 dependencies:
-  - role: geerlingguy.java
-    java_packages:
-      - openjdk-7-jdk
+  - role: telusdigital.java
+    java_version: 7
 
 galaxy_info:
   author: "Ben Visser"

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -8,13 +8,13 @@
     mode: 0644
   notify: Restart Service | tomcat7
 
-# - name: Configure | tomcat7 | change logging dir
-#   lineinfile:
-#     dest: "/etc/tomcat7/logging.properties"
-#     regexp: "^1catalina.org.apache.juli.FileHandler.directory"
-#     line: "1catalina.org.apache.juli.FileHandler.directory = {{ tomcat_log_root }}"
-#     state: present
-#   notify: Reload Service | tomcat7  
+- name: Configure | tomcat7 | change logging dir
+  lineinfile:
+    dest: "/etc/tomcat7/logging.properties"
+    regexp: "^1catalina.org.apache.juli.FileHandler.directory"
+    line: "1catalina.org.apache.juli.FileHandler.directory = {{ tomcat_log_root }}"
+    state: present
+  notify: Reload Service | tomcat7  
 
 - name: Start Service | tomcat7
   service:

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -7,6 +7,8 @@
     group: "{{ tomcat_group }}"
     mode: 0644
   notify: Restart Service | tomcat7
+  tags:
+    - tomcat
 
 - name: Configure | tomcat7 | change logging dir
   lineinfile:
@@ -14,7 +16,9 @@
     regexp: "^1catalina.org.apache.juli.FileHandler.directory"
     line: "1catalina.org.apache.juli.FileHandler.directory = {{ tomcat_log_root }}"
     state: present
-  notify: Reload Service | tomcat7  
+  notify: Restart Service | tomcat7
+  tags:
+    - tomcat
 
 - name: Start Service | tomcat7
   service:

--- a/tests/test-install.yml
+++ b/tests/test-install.yml
@@ -2,9 +2,8 @@
 - hosts: localhost
   remote_user: root
   vars:
-    java_packages:
-      - openjdk-7-jdk
+    java_version: 7
   roles:
-    - role: geerlingguy.java
+    - role: telusdigital.java
     - role: ansible-tomcat
       tomcat_enabled: false


### PR DESCRIPTION
I added our own java ansible role to use with this instead of some random's.

This is the result of my travis-ci build:
[![Build Status](https://travis-ci.org/noqcks/ansible-tomcat.svg?branch=master)](https://travis-ci.org/noqcks/ansible-tomcat)