### PR TITLE
Removed update_cache on tomcat install task

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -1,7 +1,6 @@
 ---
 - name: Install Packages | apt
   apt:
-    update_cache: yes
     state: latest
     pkg: "{{ item }}"
   with_items:


### PR DESCRIPTION
None of our other roles seem to have an update_cache param on their install tasks, and it was causing me a failure when I was running a playbook. I think for now we should leave this out of the role. 

Here is the latest travis build status:
[![Build Status](https://travis-ci.org/noqcks/ansible-tomcat.svg)](https://travis-ci.org/noqcks/ansible-tomcat)